### PR TITLE
Edit Page for UCSBOrganization plus tests and stories

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -129,7 +129,7 @@ function App() {
         {
           hasRole(currentUser, "ROLE_ADMIN") && (
             <>
-              <Route exact path="/UCSBOrganization/edit/:id" element={<UCSBOrganizationEditPage />} />
+              <Route exact path="/UCSBOrganization/edit/:orgCode" element={<UCSBOrganizationEditPage />} />
               <Route exact path="/UCSBOrganization/create" element={<UCSBOrganizationCreatePage />} />
             </>
           )

--- a/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationCreatePage.js
+++ b/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationCreatePage.js
@@ -18,7 +18,7 @@ export default function OrganizationCreatePage({storybook=false}) {
   });
 
   const onSuccess = (UCSBOrganization) => {
-    toast(`New UCSB Organization Created - orgCode: ${UCSBOrganization.orgCode} orgTranslationShort: ${UCSBOrganization.orgTranslationShort} orgTranslation: ${UCSBOrganization.orgTranslation} inactive: ${UCSBOrganization.inactive}`);
+    toast(`New UCSB Organization Created - orgCode: ${UCSBOrganization.orgCode} orgTranslationShort: ${UCSBOrganization.orgTranslationShort}`);
   }
 
   const mutation = useBackendMutation(

--- a/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationEditPage.js
+++ b/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationEditPage.js
@@ -61,7 +61,7 @@ export default function UCSBOrganizationEditPage({storybook=false}) {
             <div className="pt-2">
                 <h1>Edit UCSBOrganization</h1>
                 {
-                    UCSBOrganization && <UCSBOrganizationForm submitAction={onSubmit} buttonLabel={"Update"} initialContents={UCSBOrganization} />
+                    UCSBOrganization && <UCSBOrganizationForm initialContents={UCSBOrganization} submitAction={onSubmit} buttonLabel="Update" />
                 }
             </div>
         </BasicLayout>

--- a/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationEditPage.js
+++ b/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationEditPage.js
@@ -1,13 +1,70 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
+import UCSBOrganizationForm from 'main/components/UCSBOrganization/UCSBOrganizationForm';
+import { Navigate } from 'react-router-dom'
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function UCSBOrganizationEditPage() {
+export default function UCSBOrganizationEditPage({storybook=false}) {
+    let { orgCode } = useParams();
 
-  // Stryker disable all : placeholder for future implementation
-  return (
-    <BasicLayout>
-      <div className="pt-2">
-        <h1>Edit page not yet implemented</h1>
-      </div>
-    </BasicLayout>
-  )
+    const { data: UCSBOrganization, _error, _status } =
+        useBackend(
+            // Stryker disable next-line all : don't test internal caching of React Query
+            [`/api/UCSBOrganization?orgCode=${orgCode}`],
+            {  // Stryker disable next-line all : GET is the default, so mutating this to "" doesn't introduce a bug
+                method: "GET",
+                url: `/api/UCSBOrganization`,
+                params: {
+                    orgCode
+                }
+            }
+        );
+
+    const objectToAxiosPutParams = (UCSBOrganization) => ({
+        url: "/api/UCSBOrganization",
+        method: "PUT",
+        params: {
+            orgCode: UCSBOrganization.orgCode,
+        },
+        data: {
+            orgCode: UCSBOrganization.orgCode,
+            orgTranslationShort: UCSBOrganization.orgTranslationShort,
+            orgTranslation: UCSBOrganization.orgTranslation,
+            inactive: UCSBOrganization.inactive,
+        }
+    });
+
+    const onSuccess = (UCSBOrganization) => {
+        toast(`UCSBOrganization Updated - orgCode: ${UCSBOrganization.orgCode} orgTranslationShort: ${UCSBOrganization.orgTranslationShort}`);
+    }
+
+    const mutation = useBackendMutation(
+        objectToAxiosPutParams,
+        { onSuccess },
+        // Stryker disable next-line all : hard to set up test for caching
+        [`/api/UCSBOrganization?orgCode=${orgCode}`]
+    );
+
+    const { isSuccess } = mutation
+
+    const onSubmit = async (data) => {
+        mutation.mutate(data);
+    }
+
+    if (isSuccess && !storybook) {
+        return <Navigate to="/UCSBOrganization" />
+    }
+
+    return (
+        <BasicLayout>
+            <div className="pt-2">
+                <h1>Edit UCSBOrganization</h1>
+                {
+                    UCSBOrganization && <UCSBOrganizationForm submitAction={onSubmit} buttonLabel={"Update"} initialContents={UCSBOrganization} />
+                }
+            </div>
+        </BasicLayout>
+    )
+
 }

--- a/frontend/src/stories/pages/UCSBOrganization/UCSBOrganizationEditPage.stories.js
+++ b/frontend/src/stories/pages/UCSBOrganization/UCSBOrganizationEditPage.stories.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { rest } from "msw";
+
+import UCSBOrganizationEditPage from "main/pages/UCSBOrganization/UCSBOrganizationEditPage";
+import { ucsbOrganizationFixtures } from 'fixtures/ucsbOrganizationFixtures';
+
+export default {
+    title: 'pages/pages/UCSBOrganization/UCSBOrganizationEditPage',
+    component: UCSBOrganizationEditPage
+};
+
+const Template = () => <UCSBOrganizationEditPage storybook={true}/>;
+
+export const Default = Template.bind({});
+Default.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res( ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/UCSBOrganization', (_req, res, ctx) => {
+            return res(ctx.json(ucsbOrganizationFixtures.threeOrganizations[0]));
+        }),
+        rest.put('/api/UCSBOrganization', async (req, res, ctx) => {
+            var reqBody = await req.text();
+            window.alert("PUT: " + req.url + " and body: " + reqBody);
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ],
+}
+
+
+

--- a/frontend/src/stories/pages/UCSBOrganization/UCSBOrganizationEditPage.stories.js
+++ b/frontend/src/stories/pages/UCSBOrganization/UCSBOrganizationEditPage.stories.js
@@ -7,7 +7,7 @@ import UCSBOrganizationEditPage from "main/pages/UCSBOrganization/UCSBOrganizati
 import { ucsbOrganizationFixtures } from 'fixtures/ucsbOrganizationFixtures';
 
 export default {
-    title: 'pages/pages/UCSBOrganization/UCSBOrganizationEditPage',
+    title: 'pages/UCSBOrganization/UCSBOrganizationEditPage',
     component: UCSBOrganizationEditPage
 };
 

--- a/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationForm.test.js
+++ b/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationForm.test.js
@@ -94,9 +94,9 @@ describe("UCSBOrganizationForm tests", () => {
         const inactiveField = screen.getByTestId("UCSBOrganizationForm-inactive");
         const submitButton = screen.getByTestId("UCSBOrganizationForm-submit");
 
-        fireEvent.change(orgCodeField, { target: { value: 'DSP' } });
-        fireEvent.change(orgTranslationShortField, { target: { value: 'Delta Sig' } });
-        fireEvent.change(orgTranslationField, { target: { value: 'Delta Sigma Pi' } });
+        fireEvent.change(orgCodeField, { target: { value: 'CD' } });
+        fireEvent.change(orgTranslationShortField, { target: { value: 'Coder' } });
+        fireEvent.change(orgTranslationField, { target: { value: 'CoderSB' } });
         fireEvent.change(inactiveField, { target: { value: false } });
         fireEvent.click(submitButton);
 

--- a/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationCreatePage.test.js
+++ b/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationCreatePage.test.js
@@ -110,7 +110,7 @@ describe("UCSBOrganizationCreatePage tests", () => {
         });
 
         // assert - check that the toast was called with the expected message
-        expect(mockToast).toBeCalledWith("New UCSB Organization Created - orgCode: CD orgTranslationShort: Coder orgTranslation: CoderSB inactive: false");
+        expect(mockToast).toBeCalledWith("New UCSB Organization Created - orgCode: CD orgTranslationShort: Coder");
         expect(mockNavigate).toBeCalledWith({ "to": "/UCSBOrganization" });
 
     });

--- a/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationEditPage.test.js
+++ b/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationEditPage.test.js
@@ -1,44 +1,177 @@
-import { render, screen } from "@testing-library/react";
-import PlaceholderEditPage from "main/pages/UCSBOrganization/UCSBOrganizationEditPage";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
+import UCSBOrganizationEditPage from "main/pages/UCSBOrganization/UCSBOrganizationEditPage";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
+import mockConsole from "jest-mock-console";
 
-describe("PlaceholderEditPage tests", () => {
-
-    const axiosMock = new AxiosMockAdapter(axios);
-
-    const setupUserOnly = () => {
-        axiosMock.reset();
-        axiosMock.resetHistory();
-        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
-        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
     };
+});
 
-    const queryClient = new QueryClient();
-    test("Renders expected content", () => {
-        // arrange
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        useParams: () => ({
+            orgCode: "CD"
+        }),
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
 
-        setupUserOnly();
+describe("UCSBOrganizationEditPage tests", () => {
 
-        // act
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <PlaceholderEditPage />
-                </MemoryRouter>
-            </QueryClientProvider>
-        );
+    describe("when the backend doesn't return data", () => {
 
-        // assert
-        expect(screen.getByText("Edit page not yet implemented")).toBeInTheDocument();
+        const axiosMock = new AxiosMockAdapter(axios);
+
+        beforeEach(() => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/UCSBOrganization", { params: { orgCode: "CD" } }).timeout();
+        });
+
+        const queryClient = new QueryClient();
+        test("renders header but table is not present", async () => {
+
+            const restoreConsole = mockConsole();
+
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <UCSBOrganizationEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+            await screen.findByText("Edit UCSBOrganization");
+            expect(screen.queryByTestId("UCSBOrganizationForm-orgCode")).not.toBeInTheDocument();
+            restoreConsole();
+        });
     });
 
+    describe("tests where backend is working normally", () => {
+
+        const axiosMock = new AxiosMockAdapter(axios);
+
+        beforeEach(() => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/UCSBOrganization", { params: { orgCode: "CD" } }).reply(200, {
+                orgCode: "CD", 
+                orgTranslationShort: "Coder",
+                orgTranslation: "CoderSB",
+                inactive: false
+            });
+            axiosMock.onPut('/api/UCSBOrganization').reply(200, {
+                orgCode: "CD", 
+                orgTranslationShort: "Coder",
+                orgTranslation: "CoderSB",
+                inactive: false
+            });
+        });
+
+        const queryClient = new QueryClient();
+        test("renders without crashing", () => {
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <UCSBOrganizationEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+        });
+
+        test("Is populated with the data provided", async () => {
+
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <UCSBOrganizationEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await screen.findByTestId("UCSBOrganizationForm-orgCode");
+
+            const orgCodeField = screen.getByTestId("UCSBOrganizationForm-orgCode");
+            const orgTranslationShortField = screen.getByTestId("UCSBOrganizationForm-orgTranslationShort");
+            const orgTranslationField = screen.getByTestId("UCSBOrganizationForm-orgTranslation");
+            const inactiveField = screen.getByTestId("UCSBOrganizationForm-inactive");
+            const submitButton = screen.getByTestId("UCSBOrganizationForm-submit");
+
+            expect(orgCodeField).toHaveValue("CD");
+            expect(orgTranslationShortField).toHaveValue("Coder");
+            expect(orgTranslationField ).toHaveValue("CoderSB");
+            expect(inactiveField).toHaveValue("false");
+            expect(submitButton).toBeInTheDocument();
+        });
+
+        test("Changes when you click Update", async () => {
+
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <UCSBOrganizationEditPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await screen.findByTestId("UCSBOrganizationForm-orgCode");
+
+            const orgCodeField = screen.getByTestId("UCSBOrganizationForm-orgCode");
+            const orgTranslationShortField = screen.getByTestId("UCSBOrganizationForm-orgTranslationShort");
+            const orgTranslationField = screen.getByTestId("UCSBOrganizationForm-orgTranslation");
+            const inactiveField = screen.getByTestId("UCSBOrganizationForm-inactive");
+            const submitButton = screen.getByTestId("UCSBOrganizationForm-submit");
+
+            expect(orgCodeField).toHaveValue("CD");
+            expect(orgTranslationShortField).toHaveValue("Coder");
+            expect(orgTranslationField).toHaveValue("CoderSB");
+            expect(inactiveField).toHaveValue("false");
+
+            expect(submitButton).toBeInTheDocument();
+
+            fireEvent.change(orgCodeField, { target: { value: 'CD' } })
+            fireEvent.change(orgTranslationShortField, { target: { value: 'Coder' } })
+            fireEvent.change(orgTranslationField, { target: { value: "CoderSB" } })
+
+            fireEvent.click(submitButton);
+
+            await waitFor(() => expect(mockToast).toBeCalled());
+            expect(mockToast).toBeCalledWith("UCSBOrganization Updated - orgCode: CD orgTranslationShort: Coder");
+            expect(mockNavigate).toBeCalledWith({ "to": "/UCSBOrganization" });
+
+            expect(axiosMock.history.put.length).toBe(1); // times called
+            expect(axiosMock.history.put[0].params).toEqual({ orgCode: "CD" });
+            expect(axiosMock.history.put[0].data).toBe(JSON.stringify({
+                orgCode: "CD", 
+                orgTranslationShort: "Coder",
+                orgTranslation: "CoderSB",
+                inactive: false
+            })); // posted object
+
+        });
+
+       
+    });
 });
 
 

--- a/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationEditPage.test.js
+++ b/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationEditPage.test.js
@@ -125,7 +125,6 @@ describe("UCSBOrganizationEditPage tests", () => {
         });
 
         test("Changes when you click Update", async () => {
-
             render(
                 <QueryClientProvider client={queryClient}>
                     <MemoryRouter>
@@ -133,43 +132,34 @@ describe("UCSBOrganizationEditPage tests", () => {
                     </MemoryRouter>
                 </QueryClientProvider>
             );
-
             await screen.findByTestId("UCSBOrganizationForm-orgCode");
-
             const orgCodeField = screen.getByTestId("UCSBOrganizationForm-orgCode");
             const orgTranslationShortField = screen.getByTestId("UCSBOrganizationForm-orgTranslationShort");
             const orgTranslationField = screen.getByTestId("UCSBOrganizationForm-orgTranslation");
             const inactiveField = screen.getByTestId("UCSBOrganizationForm-inactive");
             const submitButton = screen.getByTestId("UCSBOrganizationForm-submit");
-
             expect(orgCodeField).toHaveValue("CD");
             expect(orgTranslationShortField).toHaveValue("Coder");
             expect(orgTranslationField).toHaveValue("CoderSB");
             expect(inactiveField).toHaveValue("false");
-
             expect(submitButton).toBeInTheDocument();
-
-            fireEvent.change(orgCodeField, { target: { value: 'CD' } })
-            fireEvent.change(orgTranslationShortField, { target: { value: 'Coder' } })
-            fireEvent.change(orgTranslationField, { target: { value: "CoderSB" } })
-
+            fireEvent.change(orgCodeField, { target: { value: 'aCD' } })
+            fireEvent.change(orgTranslationShortField, { target: { value: 'aCoder' } })
+            fireEvent.change(orgTranslationField, { target: { value: "aCoderSB" } })
+            fireEvent.change(inactiveField, { target: { value: "true" } })
             fireEvent.click(submitButton);
-
             await waitFor(() => expect(mockToast).toBeCalled());
             expect(mockToast).toBeCalledWith("UCSBOrganization Updated - orgCode: CD orgTranslationShort: Coder");
             expect(mockNavigate).toBeCalledWith({ "to": "/UCSBOrganization" });
-
             expect(axiosMock.history.put.length).toBe(1); // times called
-            expect(axiosMock.history.put[0].params).toEqual({ orgCode: "CD" });
+            expect(axiosMock.history.put[0].params).toEqual({ orgCode: "aCD" });
             expect(axiosMock.history.put[0].data).toBe(JSON.stringify({
-                orgCode: "CD", 
-                orgTranslationShort: "Coder",
-                orgTranslation: "CoderSB",
-                inactive: false
+                orgCode: "aCD",
+                orgTranslationShort: "aCoder",
+                orgTranslation: "aCoderSB",
+                inactive: "true"
             })); // posted object
-
         });
-
        
     });
 });


### PR DESCRIPTION
In this PR, I implemented the Edit page for UCSB Organization, and storybook and passed all the tests locally. When user click on update, the data will be updated.

Closes https://github.com/ucsb-cs156-s24/team03-s24-4pm-5/issues/24

Before Update:
<img width="1411" alt="Screenshot 2024-05-11 at 1 38 17 PM" src="https://github.com/ucsb-cs156-s24/team03-s24-4pm-5/assets/97069739/4be4d30c-dd32-46bc-864f-b15e8900363a">

After Update:

<img width="1418" alt="Screenshot 2024-05-11 at 1 38 35 PM" src="https://github.com/ucsb-cs156-s24/team03-s24-4pm-5/assets/97069739/7176dab1-b6e1-4534-b595-d0572ab3a4bb">
